### PR TITLE
Use native npm ls to find modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,7 @@ var PLUGIN_PREFIX = 'bem-tools-';
 
 var fs = require('fs'),
     path = require('path'),
-    npmls = require('npmls'),
-    npmRootPath = require('global-modules'),
-    uniq = require('lodash.uniq');
+    npm = require('npm');
 
 var bem = require('coa').Cmd()
     .name(process.argv[1])
@@ -21,47 +19,86 @@ var bem = require('coa').Cmd()
         })
         .end();
 
-var globalModules = [],
-    localModules = [];
+function getBemToolsPlugins() {
+    var globalModules, localModules;
 
-try {
-    globalModules = npmls(true);
-} catch (err) {
-    if (err.code !== 'ENOENT') throw new Error(err);
+    return new Promise(function(resolve, reject) {
+        npm.load(function() {
+            npm.config.set('global', true);
+            require('npm/lib/ls')([], true, function(err, ls) {
+                if (err) return reject(err);
+
+                globalModules = _getBemToolsPlugins(ls.dependencies);
+
+                if (localModules) {
+                    resolve(Object.assign(globalModules, localModules));
+                }
+            });
+
+            npm.config.set('global', false)
+            require('npm/lib/ls')([], true, function(err, ls) {
+                if (err) return reject(err);
+
+                localModules = _getBemToolsPlugins(ls.dependencies);
+
+                if (globalModules) {
+                    resolve(Object.assign(globalModules, localModules));
+                }
+            });
+        });
+    });
+};
+
+function _getBemToolsPlugins(tree) {
+    var plugins = {},
+        deps = Object.keys(tree);
+
+    deps.forEach(function(depName) {
+        var dep = tree[depName];
+
+        if (!plugins[depName] && depName !== 'bem-tools-core' && depName.indexOf(PLUGIN_PREFIX) === 0) {
+            plugins[depName] = dep._where;
+        }
+    });
+
+    // higher level deps override inner ones
+    deps.forEach(function(depName) {
+        var dep = tree[depName] || {};
+
+        if (dep.dependencies) {
+            plugins = Object.assign(_getBemToolsPlugins(dep.dependencies), plugins);
+        }
+    });
+
+    return plugins;
 }
 
-try {
-    localModules = npmls();
-} catch (err) {
-    if (err.code !== 'ENOENT') throw new Error(err);
-}
+getBemToolsPlugins().then(function(plugins) {
+    Object.keys(plugins).forEach(function(plugin) {
+        var commandName = plugin.replace(PLUGIN_PREFIX, ''),
+            localPluginDir = path.join('node_modules', plugin),
+            // globalPluginDir = path.join(npmRootPath, plugin);
+            // pluginPath = path.resolve(path.join(fs.existsSync(localPluginDir) ? localPluginDir: globalPluginDir, 'cli')),
+            pluginPath = path.resolve(plugins[plugin], 'node_modules', plugin, 'cli'),
+            pluginModule = null;
 
-var plugins = uniq(localModules.concat(globalModules).filter(function(module) {
-    return module.indexOf(PLUGIN_PREFIX) === 0 && module !== 'bem-tools-core';
-}));
+        try {
+            pluginModule = require(pluginPath);
+        } catch(err) {
+            // TODO: implement verbose logging
+            // console.warn('Cannot find module', plugin);
+        }
 
-plugins.forEach(function(plugin) {
-    var commandName = plugin.replace(PLUGIN_PREFIX, ''),
-        localPluginDir = path.join('node_modules', plugin),
-        globalPluginDir = path.join(npmRootPath, plugin);
-        pluginPath = path.resolve(path.join(fs.existsSync(localPluginDir) ? localPluginDir: globalPluginDir, 'cli')),
-        pluginModule = null;
-    try {
-        pluginModule = require(pluginPath);
-    } catch(err) {
-        // TODO: implement verbose logging
-        // console.warn('Cannot find module', plugin);
-    }
+        pluginModule && bem.cmd().name(commandName).apply(pluginModule).end();
+    });
 
-    pluginModule && bem.cmd().name(commandName).apply(pluginModule).end();
-});
+    bem.run(process.argv.slice(2));
+}).catch(console.error);
 
 bem.act(function(opts, args) {
     if (!Object.keys(opts).length && !Object.keys(args).length) {
         return this.usage();
     }
 });
-
-bem.run(process.argv.slice(2));
 
 module.exports = bem;

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
   "license": "MPL-2.0",
   "dependencies": {
     "coa": "^1.0.1",
-    "lodash.uniq": "^4.2.1",
-    "npmls": "^3.0.0",
-    "global-modules": "^0.2.0"
+    "npm": "^3.10.8"
   }
 }


### PR DESCRIPTION
WIP

ATM works extremely slow without caching.

Caching scheme should be as follows:
1. Always use old cache to run bem-tools plugins.
2. Fork child process to update cache in background.
